### PR TITLE
Don't require API key for Sulu

### DIFF
--- a/src/components/global/ApiSettings.tsx
+++ b/src/components/global/ApiSettings.tsx
@@ -11,7 +11,9 @@ const ApiSettings: React.FC = () => {
 
     const validateAndSaveKey = async () => {
         if (!tempKey.trim()) {
-            toast.error('Please enter an API key');
+            // It's OK for users not to have an API key for Sulu.
+            // They can still use the Judge0 without the API key but their requests will be rate limited.
+            // If they ever hit the rate limit, they can add an API key to avoid the rate limit.
             return;
         }
 

--- a/src/components/global/popups/ApiLimitAlert.tsx
+++ b/src/components/global/popups/ApiLimitAlert.tsx
@@ -10,10 +10,10 @@ interface ApiLimitAlertProps {
 const ApiLimitAlert: React.FC<ApiLimitAlertProps> = ({ isOpen, setIsOpen }) => {
     return (
         <PopupModal isOpen={isOpen} setIsOpen={setIsOpen}>
-            <PopupBox 
-                isOpen={isOpen} 
-                setIsOpen={setIsOpen} 
-                title="API Limit Exceeded" 
+            <PopupBox
+                isOpen={isOpen}
+                setIsOpen={setIsOpen}
+                title="API Limit Exceeded"
                 customClass="max-w-xs"
                 popupHeight="h-auto"
             >
@@ -22,8 +22,8 @@ const ApiLimitAlert: React.FC<ApiLimitAlertProps> = ({ isOpen, setIsOpen }) => {
                         API rate limit exceeded.
                     </p>
                     <div className="mb-6 text-sm">
-                        <a 
-                            href="https://platform.sulu.sh/portal/consumer/dashboard?period=7_days"
+                        <a
+                            href="https://platform.sulu.sh/apis/judge0"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium"

--- a/src/utils/hooks/useCodeExecution.ts
+++ b/src/utils/hooks/useCodeExecution.ts
@@ -109,12 +109,17 @@ export const useCodeExecution = (editor: React.RefObject<any>) => {
     // Unified API handlers
     const makeJudge0CERequest = async (endpoint: string, options: any, apiKey: string) => {
         const controller = executionState.startNew();
-        return fetch(`https://judge0-ce.p.sulu.sh/${endpoint}`, {
+        // Don't use Judge0 CE via Sulu for GET requests since it's rate limited when user is not authenticated, instead
+        // use Judge0 CE directly for GET requests and Sulu for POST requests.
+        const baseUrl = options.method === 'GET' ? 'https://ce.judge0.com' : 'https://judge0-ce.p.sulu.sh';
+        return fetch(`${baseUrl}/${endpoint}`, {
             ...options,
             headers: {
                 'Accept': 'application/json',
                 ...options.headers,
-                'Authorization': `Bearer ${apiKey}`
+                'Authorization': apiKey ? `Bearer ${apiKey}` : '' // Only add Authorization header if apiKey is present.
+                                                                  // This will work because Judge0 is allowed to be accessed without an API key via Sulu but is rate limited.
+                                                                  // If users ever hit the rate limit, they can add an API key to avoid the rate limit.
             },
             signal: controller.signal
         });


### PR DESCRIPTION
Hi @MaanasSehgal,

Let me explain what have I done in this PR.

Basically, to use Judge0 via Sulu, you don't need an API key from Sulu.

If you don't have an API key from Sulu, you can still use Judge0 via Sulu, but your IP address will be rate-limited.

On Judge0 only `POST /submissions` and `POST /submissions/batch` requests are paid requests, while other requests are free of charge.

That is why for `GET` requests, we can use Judge0 directly, and for `POST` requests, we can use Judge0 via Sulu.

With this approach, you will never be rate-limited for `GET` requests, and you will only be rate-limited for `POST` requests if you don't provide an API key from Sulu.

If users ever hit this rate limit, you can show them a message that they are rate limited, and if that annoys them, they can go to Sulu and grab their API key.

With this change, your extension will be even easier to use, and onboarding will be even smoother because your users don't need to do the additional step of signing up to Sulu. Again, if they ever hit the rate limit and get annoyed by it, they can always sign up and put their API key in your extension.

#### Additional notes that are not part of this PR
Also, even when they load a valid API key to your extension you don't need to use it for every `POST` request, but only when they get rate-limited. In that case you can silently try the `POST` request again with their API key. This would be a killer feature.

I haven't tested this PR, so please test if everything works and do additional changes yourself. I am here if you have any questions regarding what I have described above.

Also, I suggest updating your README so that it does not explain the steps for users to get their API key for Judge0. Your README should be so short and concise that users can be up and running in 30 seconds or less, where the reading time of README is included as well in that time. I believe you can do that.

Keep pushing! :muscle: :rocket:

Best regards,
Herman