### PR TITLE
Send X-Judge0-Region

### DIFF
--- a/src/utils/hooks/useCodeExecution.ts
+++ b/src/utils/hooks/useCodeExecution.ts
@@ -88,7 +88,7 @@ export const useCodeExecution = (editor: React.RefObject<any>) => {
         cpu_time_limit: 2,
     });
 
-    const processResults = async (tokens: string[], apiKey: string) => {
+    const processResults = async (tokens: string[], apiKey: string, region: string = 'AUTO') => {
         const controller = executionState.startNew();
         await new Promise((resolve, reject) => {
             const timeout = setTimeout(resolve, (language === 'kotlin' ? 6000 : EXECUTE_CODE_LIMIT) * testCases.testCases.length);
@@ -100,7 +100,7 @@ export const useCodeExecution = (editor: React.RefObject<any>) => {
 
         const resultsResponse = await makeJudge0CERequest(
             `submissions/batch?base64_encoded=true&tokens=${tokens.join(',')}&fields=stdout,stderr,status,compile_output,status_id,time,memory`,
-            { method: 'GET' },
+            { method: 'GET', headers: { 'X-Judge0-Region': region } },
             apiKey
         );
         return resultsResponse.json();
@@ -148,7 +148,7 @@ export const useCodeExecution = (editor: React.RefObject<any>) => {
             }
 
             const tokens = batchResponse.map(submission => submission.token);
-            let results = await processResults(tokens, apiKey);
+            let results = await processResults(tokens, apiKey, submitResponse.headers.get('X-Judge0-Region') || 'AUTO');
 
             if (!results?.submissions) {
                 testCases.ErrorMessage = `Compilation Error`;


### PR DESCRIPTION
Since you are using, as I recommended, two different endpoints for using Judge0, which internally use two different geolocating load balancers, there is a hard-to-reproduce bug but still present and some users might experience it.

The bug is the following:
1. User creates a new submissions with POST via Sulu
2. That POST request is handled by Sulu's geo-loadbalancer and redirected to region X of Judge0.
3. User create a GET request directly via Judge0
4. That GET request is handled by Judge0's geo-loadbalancer and redirected to region Y of Judge0.
5. User get 404 error since the submission does not exist in region Y but rather in region X.

To handle this edge-case Judge0 returns the following header `X-Judge0-Region` which specifies which region has handled the request. We then send this header back to Judge0 when doing the GET request.

I have not tested this code so please make sure to test it before merging. The following line should always resolve to one of the following values: `EU`, `AS`, or `NA`: `submitResponse.headers.get('X-Judge0-Region') || 'AUTO'` but I have added `|| 'AUTO'` as precaution.

When testing this simply make sure that `region` parameter in `processResults` function is set to one of the values: `EU`, `AS`, or `NA` when doing GET request for fetcing submissions.