### PR TITLE
feat: added vim keybindings with relative line numbers and cursor smooth caret animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "lucide-react": "^0.447.0",
         "monaco-editor": "^0.52.2",
         "monaco-themes": "^0.4.4",
+        "monaco-vim": "^0.4.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sonner": "^1.5.0",

--- a/src/components/main/editor/CodeEditor.tsx
+++ b/src/components/main/editor/CodeEditor.tsx
@@ -22,6 +22,8 @@ const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: Cod
     const setEditorSettings = useCFStore((state) => state.setEditorSettings);
     const { getEditorSettings } = useEditorSettings(editorSettings, setEditorSettings);
     const editorRef = useRef<HTMLDivElement>(null);
+    const vimStatusRef = useRef<HTMLDivElement>(null);
+
     useEffect(() => {
         const loadThemes = async () => {
             for (const [themeKey, themeName] of Object.entries(themesJSON)) {
@@ -61,9 +63,10 @@ const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: Cod
             }
 
             const vimEditor = monacoInstanceRef.current! as IVimEditor
+            vimEditor.vimStatusRef = vimStatusRef;
 
             if(editorSettings.keyBinding == "vim") {
-                vimEditor.vimMode = initVimMode(monacoInstanceRef.current, null);
+                vimEditor.vimMode = initVimMode(monacoInstanceRef.current, vimStatusRef.current);
             }
         };
 
@@ -71,8 +74,6 @@ const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: Cod
 
         return () => {
             if (monacoInstanceRef.current) {
-                (monacoInstanceRef.current as IVimEditor).vimMode?.dispose()
-
                 monacoInstanceRef.current.dispose();
                 monacoInstanceRef.current = null;
             }
@@ -82,6 +83,7 @@ const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: Cod
     return (
         <div className={`flex flex-col h-full w-full`}>
             <div className='h-full w-full z-0' ref={editorRef} style={editorStyle}></div>
+            <div ref={vimStatusRef} />
         </div>
     );
 }

--- a/src/components/main/editor/CodeEditor.tsx
+++ b/src/components/main/editor/CodeEditor.tsx
@@ -4,10 +4,11 @@ import 'monaco-editor/esm/vs/language/typescript/monaco.contribution';
 import 'monaco-editor/esm/vs/language/css/monaco.contribution';
 import 'monaco-editor/esm/vs/language/json/monaco.contribution';
 import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController.js';
-import { CodeEditorProps, EditorSettingsTypes } from '../../../types/types';
+import { CodeEditorProps, EditorSettingsTypes, IVimEditor } from '../../../types/types';
 import themesJSON from '../../../../themes/themelist.json';
 import { useEditorSettings } from '../../../utils/hooks/useEditorSettings';
 import { useCFStore } from '../../../zustand/useCFStore';
+import { initVimMode } from 'monaco-vim';
 
 const editorStyle: React.CSSProperties = {
     height: '250px',
@@ -48,14 +49,21 @@ const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: Cod
                     minimap: {
                         enabled: editorSettings.minimap
                     },
-                    lineNumbers: editorSettings.lineNumbers ? 'on' : 'off',
+                    lineNumbers: editorSettings.lineNumbers,
                     suggestOnTriggerCharacters: editorSettings.autoSuggestions,
                     quickSuggestions: editorSettings.autoSuggestions,
+                    cursorSmoothCaretAnimation: editorSettings.cursorSmoothCaretAnimation,
                 });
 
                 if (templateCode) {
                     monacoInstanceRef.current.setValue(templateCode);
                 }
+            }
+
+            const vimEditor = monacoInstanceRef.current! as IVimEditor
+
+            if(editorSettings.keyBinding == "vim") {
+                vimEditor.vimMode = initVimMode(monacoInstanceRef.current, null);
             }
         };
 
@@ -63,6 +71,8 @@ const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: Cod
 
         return () => {
             if (monacoInstanceRef.current) {
+                (monacoInstanceRef.current as IVimEditor).vimMode?.dispose()
+
                 monacoInstanceRef.current.dispose();
                 monacoInstanceRef.current = null;
             }

--- a/src/components/options/ui/EditorSettings.tsx
+++ b/src/components/options/ui/EditorSettings.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, Code, Settings, Palette, Eye } from 'lucide-react';
 import { useCFStore } from '../../../zustand/useCFStore';
-import { EditorSettingsTypes } from '../../../types/types';
+import { CursorSmoothCaretAnimation, EditorSettingsTypes, KeyBinding, LineNumber } from '../../../types/types';
 import { useEditorSettings } from '../../../utils/hooks/useEditorSettings';
 import CodeEditor from '../../main/editor/CodeEditor';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
@@ -166,7 +166,7 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
                                         </h3>
                                     </div>
 
-                                    <div className="space-y-5">
+                                    <div className="space-y-5 mb-6">
                                         {/* Feature Toggle Item */}
                                         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3 rounded-lg bg-gray-50 dark:bg-[#222222] hover:bg-gray-100 dark:hover:bg-[#252525] transition-colors">
                                             <div className="flex-1">
@@ -222,29 +222,6 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
                                                             <input
                                                                 type="checkbox"
                                                                 className="sr-only"
-                                                                checked={editorSettings.lineNumbers}
-                                                                onChange={() => handleToggle('lineNumbers')}
-                                                            />
-                                                            <div className={`block w-11 h-6 rounded-full transition-colors ${editorSettings.lineNumbers ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}></div>
-                                                            <div className={`absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition-transform ${editorSettings.lineNumbers ? 'transform translate-x-5' : ''}`}></div>
-                                                        </div>
-                                                        <span className="ml-3 text-gray-700 dark:text-gray-300 font-medium">Line Numbers</span>
-                                                    </label>
-                                                </div>
-                                                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-14">
-                                                    Display line numbers in the editor gutter
-                                                </p>
-                                            </div>
-                                        </div>
-
-                                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-3 rounded-lg bg-gray-50 dark:bg-[#222222] hover:bg-gray-100 dark:hover:bg-[#252525] transition-colors">
-                                            <div className="flex-1">
-                                                <div className="flex items-center gap-3">
-                                                    <label className="flex items-center cursor-pointer">
-                                                        <div className="relative">
-                                                            <input
-                                                                type="checkbox"
-                                                                className="sr-only"
                                                                 checked={editorSettings.lineWrapping}
                                                                 onChange={() => handleToggle('lineWrapping')}
                                                             />
@@ -258,6 +235,70 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
                                                     Wrap long lines of code instead of horizontal scrolling
                                                 </p>
                                             </div>
+                                        </div>
+                                    </div>
+
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                        <div className="space-y-2">
+                                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                Line Numbers
+                                            </label>
+                                            <select
+                                                value={editorSettings.lineNumbers || "on"}
+                                                onChange={(e) => {
+                                                    setEditorSettings({ ...editorSettings, lineNumbers: e.target.value as LineNumber })
+                                                }}
+                                                className="w-full cursor-pointer bg-gray-100 dark:bg-[#2a2a2a] px-3 py-2 font-medium text-gray-700 dark:text-zinc-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
+                                                aria-label="Select tab indent size"
+                                            >
+                                                <option value="on">On</option>
+                                                <option value="relative">Relative</option>
+                                                <option value="off">Off</option>
+                                            </select>
+                                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                                Controls the display of line numbers in the editor gutter.
+                                            </p>
+                                        </div>
+
+                                        <div className="space-y-2">
+                                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                Keybinding
+                                            </label>
+                                            <select
+                                                value={editorSettings.keyBinding || "standard"}
+                                                onChange={(e) => {
+                                                    setEditorSettings({ ...editorSettings, keyBinding: e.target.value as KeyBinding })
+                                                }}
+                                                className="w-full cursor-pointer bg-gray-100 dark:bg-[#2a2a2a] px-3 py-2 font-medium text-gray-700 dark:text-zinc-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
+                                                aria-label="Select tab indent size"
+                                            >
+                                                <option value="standard">Standard</option>
+                                                <option value="vim">Vim</option>
+                                            </select>
+                                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                                Keybinding to use in the editor
+                                            </p>
+                                        </div>
+
+                                        <div className="space-y-2">
+                                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                Cursor Smooth Caret Animation
+                                            </label>
+                                            <select
+                                                value={editorSettings.cursorSmoothCaretAnimation || "off"}
+                                                onChange={(e) => {
+                                                    setEditorSettings({ ...editorSettings, cursorSmoothCaretAnimation: e.target.value as CursorSmoothCaretAnimation })
+                                                }}
+                                                className="w-full cursor-pointer bg-gray-100 dark:bg-[#2a2a2a] px-3 py-2 font-medium text-gray-700 dark:text-zinc-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
+                                                aria-label="Select tab indent size"
+                                            >
+                                                <option value="on">On</option>
+                                                <option value="explicit">Explicit</option>
+                                                <option value="off">Off</option>
+                                            </select>
+                                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                                Controls whether the smooth caret animation should be enabled.
+                                            </p>
                                         </div>
                                     </div>
                                 </section>

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -50,7 +50,9 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettingsTypes = {
      lineWrapping: false,
      autoSuggestions: true,
      minimap: true,
-     lineNumbers: true,
+     lineNumbers: "on",
+     keyBinding: "standard",
+     cursorSmoothCaretAnimation: "off"
 };
 
 export const isProduction = true;

--- a/src/types/monaco-vim.d.ts
+++ b/src/types/monaco-vim.d.ts
@@ -1,0 +1,4 @@
+declare module 'monaco-vim' {
+  const initVimMode: any;
+  export { initVimMode };
+}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -98,11 +98,21 @@ export interface OptionsProps {
     setOpenConfirmationPopup: (open: boolean) => void;
 }
 
+export type KeyBinding = "standard" | "vim";
+export type LineNumber = "on" | "off" | "relative";
+export type CursorSmoothCaretAnimation = "on" | "off" | "explicit";
+
 export interface EditorSettingsTypes {
     indentSize: number;
     theme: string;
     lineWrapping: boolean;
     autoSuggestions: boolean;
     minimap: boolean;
-    lineNumbers: boolean;
+    lineNumbers: LineNumber;
+    keyBinding: KeyBinding;
+    cursorSmoothCaretAnimation: CursorSmoothCaretAnimation;
+}
+
+export interface IVimEditor extends monaco.editor.IStandaloneCodeEditor {
+  vimMode?: any;
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -114,5 +114,6 @@ export interface EditorSettingsTypes {
 }
 
 export interface IVimEditor extends monaco.editor.IStandaloneCodeEditor {
-  vimMode?: any;
+  vimMode: any;
+  vimStatusRef: React.RefObject<HTMLDivElement | null>;
 }

--- a/src/utils/hooks/useEditorSettings.ts
+++ b/src/utils/hooks/useEditorSettings.ts
@@ -59,7 +59,7 @@ export const useEditorSettings = (editorSettings: EditorSettingsTypes, setEditor
 
             if(editorSettings.keyBinding == "vim") {
                 if(!vimEditor.vimMode) {
-                    vimEditor.vimMode = initVimMode(editor, null);
+                    vimEditor.vimMode = initVimMode(editor, vimEditor.vimStatusRef.current);
                 }
             } else {
                 if (vimEditor.vimMode) {

--- a/src/utils/hooks/useEditorSettings.ts
+++ b/src/utils/hooks/useEditorSettings.ts
@@ -1,6 +1,7 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
-import { EditorSettingsTypes } from '../../types/types';
+import { EditorSettingsTypes, IVimEditor } from '../../types/types';
 import { DEFAULT_EDITOR_SETTINGS } from '../../data/constants';
+import { initVimMode } from 'monaco-vim';
 
 export const useEditorSettings = (editorSettings: EditorSettingsTypes, setEditorSettings: (settings: EditorSettingsTypes) => void) => {
 
@@ -48,10 +49,24 @@ export const useEditorSettings = (editorSettings: EditorSettingsTypes, setEditor
                 minimap: {
                     enabled: editorSettings.minimap
                 },
-                lineNumbers: editorSettings.lineNumbers ? 'on' : 'off',
+                lineNumbers: editorSettings.lineNumbers,
                 quickSuggestions: editorSettings.autoSuggestions,
-                suggestOnTriggerCharacters: editorSettings.autoSuggestions
+                suggestOnTriggerCharacters: editorSettings.autoSuggestions,
+                cursorSmoothCaretAnimation: editorSettings.cursorSmoothCaretAnimation,
             });
+
+            const vimEditor = editor as IVimEditor;
+
+            if(editorSettings.keyBinding == "vim") {
+                if(!vimEditor.vimMode) {
+                    vimEditor.vimMode = initVimMode(editor, null);
+                }
+            } else {
+                if (vimEditor.vimMode) {
+                    vimEditor.vimMode.dispose();
+                    vimEditor.vimMode = null;
+                }
+            }
         });
     }
 


### PR DESCRIPTION
# Changes done
- added [monaco-vim](https://github.com/brijeshb42/monaco-vim) npm package
- changes in editor settings
	- added option to select keybinding (standard/vim)
	- added option to select line number type (on/off/relative)
	- added option to enable cursor smooth caret animation (on/off/explicit)
- added status line for vim status (if in vim keybinding mode)