### PR TITLE
feat: Added font family selection to editor settings... >_<

### DIFF
--- a/src/components/main/editor/CodeEditor.tsx
+++ b/src/components/main/editor/CodeEditor.tsx
@@ -20,7 +20,7 @@ const editorStyle: React.CSSProperties = {
 const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: CodeEditorProps) => {
     const editorSettings = useCFStore((state) => state.editorSettings);
     const setEditorSettings = useCFStore((state) => state.setEditorSettings);
-    const { getEditorSettings } = useEditorSettings(editorSettings, setEditorSettings);
+    const { getEditorSettings, applyEditorSettings } = useEditorSettings(editorSettings, setEditorSettings);
     const editorRef = useRef<HTMLDivElement>(null);
     const vimStatusRef = useRef<HTMLDivElement>(null);
 
@@ -44,6 +44,7 @@ const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: Cod
                     language: language,
                     theme: editorSettings.theme,
                     fontSize: fontSize,
+                    fontFamily: editorSettings.fontFamily,
                     tabSize: editorSettings.indentSize,
                     automaticLayout: true,
                     readOnly: false,
@@ -66,9 +67,7 @@ const CodeEditor = ({ monacoInstanceRef, language, fontSize, templateCode }: Cod
             const vimEditor = monacoInstanceRef.current! as IVimEditor
             vimEditor.vimStatusRef = vimStatusRef;
 
-            if(editorSettings.keyBinding == "vim") {
-                vimEditor.vimMode = initVimMode(monacoInstanceRef.current, vimStatusRef.current);
-            }
+            applyEditorSettings();
         };
 
         loadThemes();

--- a/src/components/options/ui/EditorSettings.tsx
+++ b/src/components/options/ui/EditorSettings.tsx
@@ -9,6 +9,20 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { PREVIEW_CODE } from '../../../data/constants';
 import { formatCode } from '../../../utils/helper';
 
+// Define font options as a constant for cleaner code
+const FONT_FAMILY_OPTIONS = [
+    { value: "JetBrains Mono, monospace", label: "JetBrains Mono" },
+    { value: "Fira Code, monospace", label: "Fira Code" },
+    { value: "Cascadia Code, monospace", label: "Cascadia Code" },
+    { value: "Source Code Pro, monospace", label: "Source Code Pro" },
+    { value: "Menlo, monospace", label: "Menlo" },
+    { value: "Roboto Mono, monospace", label: "Roboto Mono" },
+    { value: "Ubuntu Mono, monospace", label: "Ubuntu Mono" },
+    { value: "Consolas, 'Courier New', monospace", label: "Consolas" },
+    { value: "'Courier New', Courier, monospace", label: "Courier New" },
+    { value: "monospace", label: "Monospace" }
+];
+
 interface EditorSettingsProps {
     isOpen: boolean;
     onClose: () => void;
@@ -154,6 +168,29 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
                                                 Color scheme for the code editor
                                             </p>
                                         </div>
+
+                                        <div className="space-y-2">
+                                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                Font Family
+                                            </label>
+                                            <select
+                                                value={editorSettings.fontFamily || "JetBrains Mono, monospace"}
+                                                onChange={(e) => {
+                                                    setEditorSettings({ ...editorSettings, fontFamily: e.target.value })
+                                                }}
+                                                className="w-full cursor-pointer bg-gray-100 dark:bg-[#2a2a2a] px-3 py-2 font-medium text-gray-700 dark:text-zinc-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
+                                                aria-label="Select font family"
+                                            >
+                                                {FONT_FAMILY_OPTIONS.map((font) => (
+                                                    <option key={font.value} value={font.value}>
+                                                        {font.label}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                                Select the font for the code editor.
+                                            </p>
+                                        </div>
                                     </div>
                                 </section>
 
@@ -249,7 +286,7 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
                                                     setEditorSettings({ ...editorSettings, lineNumbers: e.target.value as LineNumber })
                                                 }}
                                                 className="w-full cursor-pointer bg-gray-100 dark:bg-[#2a2a2a] px-3 py-2 font-medium text-gray-700 dark:text-zinc-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                                aria-label="Select tab indent size"
+                                                aria-label="Select line number style"
                                             >
                                                 <option value="on">On</option>
                                                 <option value="relative">Relative</option>
@@ -270,7 +307,7 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
                                                     setEditorSettings({ ...editorSettings, keyBinding: e.target.value as KeyBinding })
                                                 }}
                                                 className="w-full cursor-pointer bg-gray-100 dark:bg-[#2a2a2a] px-3 py-2 font-medium text-gray-700 dark:text-zinc-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                                aria-label="Select tab indent size"
+                                                aria-label="Select keybinding mode"
                                             >
                                                 <option value="standard">Standard</option>
                                                 <option value="vim">Vim</option>
@@ -290,7 +327,7 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
                                                     setEditorSettings({ ...editorSettings, cursorSmoothCaretAnimation: e.target.value as CursorSmoothCaretAnimation })
                                                 }}
                                                 className="w-full cursor-pointer bg-gray-100 dark:bg-[#2a2a2a] px-3 py-2 font-medium text-gray-700 dark:text-zinc-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                                                aria-label="Select tab indent size"
+                                                aria-label="Select smooth caret animation setting"
                                             >
                                                 <option value="on">On</option>
                                                 <option value="explicit">Explicit</option>

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -53,7 +53,8 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettingsTypes = {
   lineNumbers: "on",
   keyBinding: "standard",
   cursorSmoothCaretAnimation: "off",
-  cursorStyle: "line"
+  cursorStyle: "line",
+  fontFamily: "JetBrains Mono, monospace"
 };
 
 export const DEFAULT_SHORTCUT_SETTINGS: ShortcutSettings = {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -113,6 +113,7 @@ export interface EditorSettingsTypes {
     keyBinding: KeyBinding;
     cursorSmoothCaretAnimation: CursorSmoothCaretAnimation;
     cursorStyle: CursorStyle;
+    fontFamily: string;
 }
 
 export interface IVimEditor extends monaco.editor.IStandaloneCodeEditor {

--- a/src/utils/hooks/useEditorSettings.ts
+++ b/src/utils/hooks/useEditorSettings.ts
@@ -54,6 +54,7 @@ export const useEditorSettings = (editorSettings: EditorSettingsTypes, setEditor
                 suggestOnTriggerCharacters: editorSettings.autoSuggestions,
                 cursorSmoothCaretAnimation: editorSettings.cursorSmoothCaretAnimation,
                 cursorStyle: editorSettings.cursorStyle || 'line',
+                fontFamily: editorSettings.fontFamily,
             });
 
             const vimEditor = editor as IVimEditor;
@@ -75,5 +76,6 @@ export const useEditorSettings = (editorSettings: EditorSettingsTypes, setEditor
         getEditorSettings,
         handleToggle,
         saveEditorSettings,
+        applyEditorSettings,
     }
 }


### PR DESCRIPTION
### Description
Adds a font selection dropdown to the Editor Settings modal, allowing users to choose their preferred font for the code editor.

### What was changed
* Added `fontFamily` to the `EditorSettingsTypes` (`src/types/types.d.ts`).
* Added a default `fontFamily` to `DEFAULT_EDITOR_SETTINGS` (`src/data/constants.ts`).
* The `fontFamily` setting is now passed to the Monaco editor on creation (`src/components/main/editor/CodeEditor.tsx`).
* The `fontFamily` setting is now applied on change via `editor.updateOptions` (`src/utils/hooks/useEditorSettings.ts`).
* Added a `<select>` dropdown in the "Editor Appearance" section of the settings modal (`src/components/options/ui/EditorSettings.tsx`).
* Defined `FONT_FAMILY_OPTIONS` constant in `EditorSettings.tsx` for cleaner code and better maintainability.

### How to test
1.  Run the extension and open the settings panel.
2.  Go to "Editor Appearance" -> "Font Family".
3.  Select a new font from the dropdown.
4.  The font in the "Live Preview" editor should update instantly.
5.  Close and reopen the settings panel; the font selection should be saved and remembered.

### Reference Screenshots
<img width="1315" height="1244" alt="Screenshot 2025-11-21 022616" src="https://github.com/user-attachments/assets/b7b59f5c-7b6a-4610-9895-4890dddf836d" />
<img width="1336" height="849" alt="Screenshot 2025-11-21 022552" src="https://github.com/user-attachments/assets/04190a67-5525-4663-a958-d863fd38e206" />