### PR TITLE
feat: add optional local execution backend for Codeforces Lite

### DIFF
--- a/cf-local-runner/README.md
+++ b/cf-local-runner/README.md
@@ -1,0 +1,44 @@
+# Codeforces Local Runner
+
+Local execution server for the **Codeforces-Lite** browser extension.  
+Allows running code on your own machine instead of using Judge0.
+
+> ⚠️ Executes code locally. Use only with trusted code.
+
+---
+
+## Features
+
+- Local code execution (no external API)
+- Faster runs for development and testing
+- Supports multiple test cases
+- Binary caching for C/C++
+- Automatic cleanup on start and shutdown
+- Cross-platform (Linux, macOS, Windows*)
+
+\* C/C++ on Windows requires WSL, MinGW, or MSYS2.
+
+---
+
+## Supported Languages
+
+- C  
+- C++  
+- Python  
+
+---
+
+## Requirements
+
+- Python 3.9+
+- pip
+- C/C++ compiler (for C/C++ execution)
+
+---
+
+## Quick Start
+
+```bash
+cd cf_local_runner
+python start.py
+

--- a/cf-local-runner/cache.py
+++ b/cf-local-runner/cache.py
@@ -1,0 +1,26 @@
+# cache.py
+import os
+import hashlib
+import shutil
+
+CACHE_DIR = os.path.expanduser("~/.cf_binary_cache")
+
+def ensure_cache():
+    os.makedirs(CACHE_DIR, exist_ok=True)
+
+def code_hash(code: str, compile_cmd: list[str]) -> str:
+    h = hashlib.sha256()
+    h.update(code.encode())
+    h.update(" ".join(compile_cmd).encode())
+    return h.hexdigest()
+
+def get_cached_binary(hash_key: str) -> str | None:
+    path = os.path.join(CACHE_DIR, hash_key)
+    return path if os.path.exists(path) else None
+
+def save_binary(binary_path: str, hash_key: str) -> str:
+    ensure_cache()
+    target = os.path.join(CACHE_DIR, hash_key)
+    shutil.move(binary_path, target)
+    os.chmod(target, 0o755)
+    return target

--- a/cf-local-runner/executor.py
+++ b/cf-local-runner/executor.py
@@ -65,7 +65,7 @@ def execute(code: str, language: str, inputs: list[str], time_limit: int):
                         "results": []
                     }
 
-                binary_path = os.path.join(tmpdir, "main")
+                binary_path = os.path.join(tmpdir, "main") if platform.system() != "Windows" else os.path.join(tmpdir, "main.exe") 
                 os.chmod(binary_path, 0o755)
 
                 if lang["cache"]:

--- a/cf-local-runner/executor.py
+++ b/cf-local-runner/executor.py
@@ -1,0 +1,120 @@
+import subprocess
+import tempfile
+import os
+import shutil
+import time
+import signal
+import platform
+import logging
+
+from languages import LANGUAGES
+from cache import code_hash, get_cached_binary, save_binary
+
+log = logging.getLogger("executor")
+
+
+def kill_process(proc):
+    try:
+        if platform.system() != "Windows":
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        else:
+            proc.kill()
+    except Exception as e:
+        log.warning(f"Failed to kill process: {e}")
+
+
+def execute(code: str, language: str, inputs: list[str], time_limit: int):
+    lang = LANGUAGES[language]
+    tmpdir = tempfile.mkdtemp(prefix="cf_")
+    results = []
+
+    log.info(f"Execution started | language={language} | testcases={len(inputs)}")
+
+    try:
+        # ---------- WRITE SOURCE ----------
+        src_path = os.path.join(tmpdir, lang["source"])
+        with open(src_path, "w") as f:
+            f.write(code)
+
+        run_cmd = lang["run"]
+
+        # ---------- COMPILE ----------
+        if lang["compile"]:
+            compile_cmd = lang["compile"]
+            h = code_hash(code, compile_cmd)
+
+            cached = get_cached_binary(h) if lang["cache"] else None
+
+            if cached:
+                log.info("Using cached binary")
+                run_cmd = [cached]
+            else:
+                log.info("Compiling source")
+                cp = subprocess.run(
+                    compile_cmd,
+                    cwd=tmpdir,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True
+                )
+
+                if cp.returncode != 0:
+                    log.error("Compilation failed")
+                    return {
+                        "compile_error": cp.stderr,
+                        "results": []
+                    }
+
+                binary_path = os.path.join(tmpdir, "main")
+                os.chmod(binary_path, 0o755)
+
+                if lang["cache"]:
+                    run_cmd = [save_binary(binary_path, h)]
+                else:
+                    run_cmd = [binary_path]
+
+        # ---------- RUN TEST CASES ----------
+        for i, input_data in enumerate(inputs):
+            log.info(f"Running test case {i + 1}")
+            start = time.time()
+
+            proc = subprocess.Popen(
+                run_cmd,
+                cwd=tmpdir,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                preexec_fn=os.setsid if platform.system() != "Windows" else None
+            )
+
+            try:
+                stdout, stderr = proc.communicate(
+                    input=input_data,
+                    timeout=time_limit
+                )
+            except subprocess.TimeoutExpired:
+                log.warning("Time limit exceeded")
+                kill_process(proc)
+                results.append({
+                    "stdout": "",
+                    "stderr": "Time Limit Exceeded",
+                    "time": time_limit
+                })
+                continue
+
+            results.append({
+                "stdout": stdout,
+                "stderr": stderr,
+                "time": f"{time.time() - start:.3f}"
+            })
+
+        return {
+            "compile_error": "",
+            "results": results
+        }
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        log.info("Temporary directory cleaned")
+

--- a/cf-local-runner/languages.py
+++ b/cf-local-runner/languages.py
@@ -1,5 +1,5 @@
-# languages.py
 import os
+import platform
 
 LANGUAGES = {
     "c": {
@@ -16,8 +16,8 @@ LANGUAGES = {
     },
     "python": {
         "source": "main.py",
-        "compile": None,           # interpreted
-        "run": ["python3", "main.py"],
+        "compile": None,
+        "run": ["python3" if platform.system() != "Windows" else "python", "main.py"],
         "cache": False,
     },
 }

--- a/cf-local-runner/languages.py
+++ b/cf-local-runner/languages.py
@@ -1,0 +1,26 @@
+# languages.py
+import os
+
+LANGUAGES = {
+    "c": {
+        "source": "main.c",
+        "compile": ["gcc", "main.c", "-O2", "-std=gnu11", "-o", "main"],
+        "run": ["./main"],
+        "cache": True,
+    },
+    "cpp": {
+        "source": "main.cpp",
+        "compile": ["g++", "main.cpp", "-O2", "-std=gnu++17", "-o", "main"],
+        "run": ["./main"],
+        "cache": True,
+    },
+    "python": {
+        "source": "main.py",
+        "compile": None,           # interpreted
+        "run": ["python3", "main.py"],
+        "cache": False,
+    },
+}
+
+def is_supported(language: str) -> bool:
+    return language in LANGUAGES

--- a/cf-local-runner/requirements.txt
+++ b/cf-local-runner/requirements.txt
@@ -1,0 +1,2 @@
+#requirement.txt
+flask

--- a/cf-local-runner/server.py
+++ b/cf-local-runner/server.py
@@ -1,0 +1,90 @@
+from flask import Flask, request, jsonify
+import logging
+import signal
+import sys
+import shutil
+import os
+
+from executor import execute
+from languages import is_supported
+from cache import CACHE_DIR, ensure_cache
+
+# ---------- LOGGING ----------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+)
+
+log = logging.getLogger("server")
+
+app = Flask(__name__)
+
+
+def cleanup_cache():
+    if os.path.exists(CACHE_DIR):
+        log.info("Cleaning binary cache")
+        shutil.rmtree(CACHE_DIR, ignore_errors=True)
+    ensure_cache()
+
+
+def ask_port(default=5000):
+    try:
+        value = input(f"Enter port (default {default}): ").strip()
+        if not value:
+            return default
+        port = int(value)
+        if port < 1024 or port > 65535:
+            raise ValueError
+        return port
+    except ValueError:
+        print("❌ Invalid port. Using default.")
+        return default
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok"})
+
+
+@app.route("/run", methods=["POST"])
+def run():
+    data = request.json or {}
+
+    code = data.get("code", "")
+    language = data.get("language", "")
+    inputs = data.get("inputs", [])
+    time_limit = int(data.get("timeLimit", 2))
+
+    log.info(f"Run request | language={language}")
+
+    if not is_supported(language):
+        return jsonify({
+            "compile_error": f"Language '{language}' not supported",
+            "results": []
+        })
+
+    result = execute(code, language, inputs, time_limit)
+    return jsonify(result)
+
+
+def shutdown_handler(sig, frame):
+    log.info("Shutting down server")
+    cleanup_cache()
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    print("🚀 Codeforces Local Runner")
+    print("Supported languages: C, C++, Python")
+    print("⚠️ Executes code on your machine. Run trusted code only.\n")
+
+    cleanup_cache()
+
+    signal.signal(signal.SIGINT, shutdown_handler)
+    signal.signal(signal.SIGTERM, shutdown_handler)
+
+    port = ask_port()
+    log.info(f"Starting server on port {port}")
+
+    app.run(host="127.0.0.1", port=port)
+

--- a/cf-local-runner/start.py
+++ b/cf-local-runner/start.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import subprocess
+import venv
+
+VENV_DIR = "venv"
+
+
+def run(cmd):
+    subprocess.check_call(cmd, shell=True)
+
+
+def main():
+    try:
+        if not os.path.exists(VENV_DIR):
+            print("📦 Creating virtual environment")
+            venv.create(VENV_DIR, with_pip=True)
+
+        python = os.path.join(
+            VENV_DIR,
+            "Scripts" if os.name == "nt" else "bin",
+            "python"
+        )
+
+        print("📥 Installing requirements")
+        run(f"{python} -m pip install -r requirements.txt")
+
+        print("🚀 Starting local runner (Ctrl+C to stop)")
+        run(f"{python} server.py")
+
+    except KeyboardInterrupt:
+        print("\n👋 Local runner stopped")
+
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Failed to start server: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/components/global/ApiSettings.tsx
+++ b/src/components/global/ApiSettings.tsx
@@ -59,24 +59,30 @@ const ApiSettings: React.FC = () => {
         toast.success('API key removed');
     };
 
-    // Handle port input change
+    
+    const isValidNumericString = (value: string): boolean => {
+        if (value === '') return true;
+        return /^\d+$/.test(value);
+    };
+
+
     const handlePortChange = (value: string) => {
+        if (!isValidNumericString(value)) {
+            return;
+        }
+
         if (value === '') {
             setLocalPort('');
             return;
         }
 
-        const numValue = parseInt(value, 10);
-        
-        if (!isNaN(numValue)) {
-            setLocalPort(value);
-        }
+        setLocalPort(value);
     };
 
     const savePort = () => {
-        const numValue = parseInt(localPort, 10);
+        const trimmedPort = localPort.trim();
         
-        if (localPort === '' || isNaN(numValue)) {
+        if (trimmedPort === '' || !isValidNumericString(trimmedPort)) {
             setLocalPort('5000');
             setSavedPort('5000');
             localStorage.setItem('localRunnerPort', '5000');
@@ -84,15 +90,17 @@ const ApiSettings: React.FC = () => {
             return;
         }
 
+        const numValue = parseInt(trimmedPort, 10);
+
         if (numValue < 1024 || numValue > 65535) {
             toast.error('Invalid port. Must be between 1024 and 65535');
-            setLocalPort(savedPort); 
+            setLocalPort(savedPort);
             return;
         }
 
-        localStorage.setItem('localRunnerPort', localPort);
-        setSavedPort(localPort);
-        toast.success(`Port saved: ${localPort}`);
+        localStorage.setItem('localRunnerPort', trimmedPort);
+        setSavedPort(trimmedPort);
+        toast.success(`Port saved: ${trimmedPort}`);
     };
 
     const handlePortKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/global/ApiSettings.tsx
+++ b/src/components/global/ApiSettings.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Check, Edit2, Trash2, Key, ExternalLink } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { Check, Edit2, Trash2, Key, ExternalLink, Server } from 'lucide-react';
 import { toast } from 'sonner';
 import { useCFStore } from '../../zustand/useCFStore';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -9,6 +9,20 @@ const ApiSettings: React.FC = () => {
     const setApiKey = useCFStore((state) => state.setApiKey);
     const [isEditing, setIsEditing] = useState(false);
     const [tempKey, setTempKey] = useState('');
+
+    // Backend state
+    const [executionBackend, setExecutionBackend] = useState<'judge0' | 'local'>(
+        (localStorage.getItem('executionBackend') as 'judge0' | 'local') || 'judge0'
+    );
+    const [localPort, setLocalPort] = useState(
+        localStorage.getItem('localRunnerPort') || '5000'
+    );
+
+    // Ensure defaults
+    useEffect(() => {
+        localStorage.setItem('executionBackend', executionBackend);
+        localStorage.setItem('localRunnerPort', localPort);
+    }, [executionBackend, localPort]);
 
     const validateAndSaveKey = async () => {
         if (!tempKey.trim()) {
@@ -63,91 +77,182 @@ const ApiSettings: React.FC = () => {
                 animate={{ opacity: 1 }}
                 transition={{ delay: 0.1, duration: 0.3 }}
             >
-                <div className="py-4">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                            <Key size={16} className="text-gray-500" />
-                            <span className="font-medium text-gray-700 dark:text-gray-300">
-                                Judge0 API Key
-                            </span>
-                        </div>
-                        <div className="flex items-center gap-3">
-                            {apiKey && (
-                                <motion.button
-                                    onClick={deleteKey}
-                                    className="text-red-500 hover:text-red-600"
-                                    whileHover={{ scale: 1.1 }}
-                                    whileTap={{ scale: 0.95 }}
-                                >
-                                    <Trash2 size={18} />
-                                </motion.button>
-                            )}
-                            <motion.button
-                                onClick={() => {
-                                    setIsEditing(!isEditing);
-                                    setTempKey(apiKey);
-                                }}
-                                className="text-blue-500 hover:text-blue-600"
-                                whileHover={{ scale: 1.1 }}
-                                whileTap={{ scale: 0.95 }}
-                            >
-                                <Edit2 size={18} />
-                            </motion.button>
-                        </div>
+                {/* Backend Selector */}
+                <div className="py-4 border-b dark:border-zinc-800">
+                    <div className="flex items-center gap-2 mb-3">
+                        <Server size={16} className="text-gray-500" />
+                        <span className="font-medium text-gray-700 dark:text-gray-300">
+                            Execution Backend
+                        </span>
                     </div>
+                    <div className="flex gap-2">
+                        <motion.button
+                            onClick={() => {
+                                setExecutionBackend('judge0');
+                                toast.success('Switched to Judge0');
+                            }}
+                            className={`px-4 py-2 rounded-lg text-sm transition ${
+                                executionBackend === 'judge0'
+                                    ? 'bg-blue-500 text-white'
+                                    : 'bg-gray-100 dark:bg-zinc-700 dark:text-white'
+                            }`}
+                            whileHover={{ scale: 1.05 }}
+                            whileTap={{ scale: 0.95 }}
+                        >
+                            Judge0
+                        </motion.button>
+                        <motion.button
+                            onClick={() => {
+                                setExecutionBackend('local');
+                                toast.success('Switched to Local Runner');
+                            }}
+                            className={`px-4 py-2 rounded-lg text-sm transition ${
+                                executionBackend === 'local'
+                                    ? 'bg-blue-500 text-white'
+                                    : 'bg-gray-100 dark:bg-zinc-700 dark:text-white'
+                            }`}
+                            whileHover={{ scale: 1.05 }}
+                            whileTap={{ scale: 0.95 }}
+                        >
+                            Local Runner
+                        </motion.button>
+                    </div>
+                </div>
 
-                    <AnimatePresence>
-                        {isEditing ? (
-                            <motion.div 
-                                className="mt-3"
-                                initial={{ opacity: 0, height: 0 }}
-                                animate={{ opacity: 1, height: 'auto' }}
-                                exit={{ opacity: 0, height: 0 }}
-                                transition={{ duration: 0.2 }}
-                            >
-                                <input
-                                    type="password"
-                                    placeholder="Enter your Judge0 API key"
-                                    value={tempKey}
-                                    onChange={(e) => setTempKey(e.target.value)}
-                                    className="w-full p-2 mb-3 border bg-zinc-200 text-zinc-800 dark:bg-zinc-800 dark:border-zinc-700 dark:text-white"
-                                />
-                                <div className="flex gap-3">
+                {/* Judge0 API Key Section */}
+                <AnimatePresence>
+                    {executionBackend === 'judge0' && (
+                        <motion.div
+                            className="py-4"
+                            initial={{ opacity: 0, height: 0 }}
+                            animate={{ opacity: 1, height: 'auto' }}
+                            exit={{ opacity: 0, height: 0 }}
+                            transition={{ duration: 0.2 }}
+                        >
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-2">
+                                    <Key size={16} className="text-gray-500" />
+                                    <span className="font-medium text-gray-700 dark:text-gray-300">
+                                        Judge0 API Key
+                                    </span>
+                                </div>
+                                <div className="flex items-center gap-3">
+                                    {apiKey && (
+                                        <motion.button
+                                            onClick={deleteKey}
+                                            className="text-red-500 hover:text-red-600"
+                                            whileHover={{ scale: 1.1 }}
+                                            whileTap={{ scale: 0.95 }}
+                                        >
+                                            <Trash2 size={18} />
+                                        </motion.button>
+                                    )}
                                     <motion.button
                                         onClick={() => {
-                                            setIsEditing(false);
-                                            setTempKey('');
+                                            setIsEditing(!isEditing);
+                                            setTempKey(apiKey);
                                         }}
-                                        className="px-4 py-2 bg-gray-100 hover:bg-gray-200 dark:bg-zinc-700 dark:hover:bg-zinc-600 dark:text-white"
-                                        whileHover={{ scale: 1.05 }}
+                                        className="text-blue-500 hover:text-blue-600"
+                                        whileHover={{ scale: 1.1 }}
                                         whileTap={{ scale: 0.95 }}
                                     >
-                                        Cancel
-                                    </motion.button>
-                                    <motion.button
-                                        onClick={validateAndSaveKey}
-                                        className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white flex items-center gap-2"
-                                        whileHover={{ scale: 1.05 }}
-                                        whileTap={{ scale: 0.95 }}
-                                    >
-                                        <Check size={16} /> Save Key
+                                        <Edit2 size={18} />
                                     </motion.button>
                                 </div>
-                            </motion.div>
-                        ) : (
-                            apiKey && (
-                                <motion.div 
-                                    className="text-sm text-gray-500"
-                                    initial={{ opacity: 0 }}
-                                    animate={{ opacity: 1 }}
-                                    transition={{ duration: 0.3 }}
-                                >
-                                    API key is set and ready to use
-                                </motion.div>
-                            )
-                        )}
-                    </AnimatePresence>
-                </div>
+                            </div>
+
+                            <AnimatePresence>
+                                {isEditing ? (
+                                    <motion.div 
+                                        className="mt-3"
+                                        initial={{ opacity: 0, height: 0 }}
+                                        animate={{ opacity: 1, height: 'auto' }}
+                                        exit={{ opacity: 0, height: 0 }}
+                                        transition={{ duration: 0.2 }}
+                                    >
+                                        <input
+                                            type="password"
+                                            placeholder="Enter your Judge0 API key"
+                                            value={tempKey}
+                                            onChange={(e) => setTempKey(e.target.value)}
+                                            className="w-full p-2 mb-3 border bg-zinc-200 text-zinc-800 dark:bg-zinc-800 dark:border-zinc-700 dark:text-white"
+                                        />
+                                        <div className="flex gap-3">
+                                            <motion.button
+                                                onClick={() => {
+                                                    setIsEditing(false);
+                                                    setTempKey('');
+                                                }}
+                                                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 dark:bg-zinc-700 dark:hover:bg-zinc-600 dark:text-white"
+                                                whileHover={{ scale: 1.05 }}
+                                                whileTap={{ scale: 0.95 }}
+                                            >
+                                                Cancel
+                                            </motion.button>
+                                            <motion.button
+                                                onClick={validateAndSaveKey}
+                                                className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white flex items-center gap-2"
+                                                whileHover={{ scale: 1.05 }}
+                                                whileTap={{ scale: 0.95 }}
+                                            >
+                                                <Check size={16} /> Save Key
+                                            </motion.button>
+                                        </div>
+                                    </motion.div>
+                                ) : (
+                                    apiKey && (
+                                        <motion.div 
+                                            className="text-sm text-gray-500"
+                                            initial={{ opacity: 0 }}
+                                            animate={{ opacity: 1 }}
+                                            transition={{ duration: 0.3 }}
+                                        >
+                                            API key is set and ready to use
+                                        </motion.div>
+                                    )
+                                )}
+                            </AnimatePresence>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+
+                {/* Local Runner Settings */}
+                <AnimatePresence>
+                    {executionBackend === 'local' && (
+                        <motion.div
+                            className="py-4"
+                            initial={{ opacity: 0, height: 0 }}
+                            animate={{ opacity: 1, height: 'auto' }}
+                            exit={{ opacity: 0, height: 0 }}
+                            transition={{ duration: 0.2 }}
+                        >
+                            <div className="flex items-center gap-2 mb-3">
+                                <Server size={16} className="text-gray-500" />
+                                <span className="font-medium text-gray-700 dark:text-gray-300">
+                                    Local Runner Port
+                                </span>
+                            </div>
+                            <input
+                                type="number"
+                                min={1}
+                                max={65535}
+                                value={localPort}
+                                onChange={(e) => {
+                                    const v = Number(e.target.value);
+                                    if (v >= 1 && v <= 65535) {
+                                        setLocalPort(e.target.value);
+                                        localStorage.setItem('localRunnerPort', e.target.value);
+                                    }
+                                }}
+                                className="w-full p-2 border bg-zinc-200 text-zinc-800 dark:bg-zinc-800 dark:border-zinc-700 dark:text-white"
+                                placeholder="5000"
+                            />
+                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                                Valid range: 1 – 65535. Ensure your local server is running.
+                            </p>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
             </motion.div>
         </motion.div>
     );

--- a/src/components/global/popups/ApiLimitAlert.tsx
+++ b/src/components/global/popups/ApiLimitAlert.tsx
@@ -10,7 +10,7 @@ interface ApiLimitAlertProps {
 const ApiInstructions = () => (
   <div className="text-sm text-left mt-4">
     <p className="font-bold text-xl mb-4 text-gray-800 dark:text-gray-200">
-      How to Get API Key
+      How to Get Judge0 API Key
     </p>
 
     <ol className="list-decimal list-inside space-y-2 text-gray-700 dark:text-darkText-400 leading-relaxed">
@@ -57,27 +57,65 @@ const ApiInstructions = () => (
   </div>
 );
 
+const LocalRunnerInstructions = () => (
+  <div className="text-sm text-left mt-6">
+    <p className="font-bold text-lg mb-3 text-gray-800 dark:text-gray-200">
+      Alternative: Use Local Runner (No API Key Required)
+    </p>
+    <ol className="list-decimal list-inside space-y-2 text-gray-700 dark:text-darkText-400 leading-relaxed">
+      <li>
+        Open <span className="text-black dark:text-white">API Settings</span>.
+      </li>
+      <li>
+        Enable{" "}
+        <span className="text-black dark:text-white">
+          Use Local Runner
+        </span>
+        .
+      </li>
+      <li>
+        Set the port number{" "}
+        <span className="text-black dark:text-white">(default: 5000)</span>.
+      </li>
+      <li>
+        Start the local server on your machine.
+      </li>
+      <li>
+        Click <span className="text-black dark:text-white">Run</span> again.
+      </li>
+    </ol>
+    <p className="mt-2 text-xs opacity-70">
+      Local Runner executes code on your own machine and does not require any
+      external API or internet access.
+    </p>
+  </div>
+);
 const ApiLimitAlert: React.FC<ApiLimitAlertProps> = ({ isOpen, setIsOpen }) => {
   return (
     <PopupModal isOpen={isOpen} setIsOpen={setIsOpen}>
       <PopupBox
         isOpen={isOpen}
         setIsOpen={setIsOpen}
-        title="API Key Required"
+        title="Execution Setup Required"
         customClass="font-bold text-xl text-gray-800 dark:text-gray-200"
         popupHeight="h-auto"
       >
         <div className="text-gray-700 dark:text-darkText-400 leading-relaxed text-sm">
           <p className="mb-4">
-            To use the code execution feature, you must add your free API key from RapidAPI.
+            You are currently using the{" "}
+            <span className="font-medium text-black dark:text-white">
+              Judge0 execution backend
+            </span>
+            , which requires an API key.
           </p>
 
           <ApiInstructions />
 
-          <p className="mt-4">
-            For detailed instructions, click{" "}
+          <LocalRunnerInstructions />
+          <p className="mt-6">
+            For detailed documentation, click{" "}
             <a
-              href="https://github.com/MaanasSehgal/Codeforces-Lite?tab=readme-ov-file#how-to-get-api-key"
+              href="https://github.com/MaanasSehgal/Codeforces-Lite"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium"

--- a/src/components/global/popups/LocalRunnerAlert.tsx
+++ b/src/components/global/popups/LocalRunnerAlert.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import PopupModal from "./PopupModal";
+import PopupBox from "./PopupBox";
+
+interface LocalRunnerAlertProps {
+  isOpen: boolean;
+  setIsOpen: (v: boolean) => void;
+  port: number;
+}
+
+const LocalRunnerAlert: React.FC<LocalRunnerAlertProps> = ({ isOpen, setIsOpen, port }) => {
+  return (
+    <PopupModal isOpen={isOpen} setIsOpen={setIsOpen}>
+      <PopupBox
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        title="Local Runner Not Running"
+        customClass="font-bold text-xl text-gray-800 dark:text-gray-200"
+        popupHeight="h-auto"
+      >
+        <div className="text-gray-700 dark:text-darkText-400 leading-relaxed text-sm">
+          <p className="mb-3">
+            The local execution server could not be reached on port{" "}
+            <strong className="text-black dark:text-white">{port}</strong>.
+          </p>
+          <p className="mb-2">To fix this:</p>
+          <ol className="list-decimal list-inside space-y-1">
+            <li>Open a terminal</li>
+            <li>Navigate to the local runner directory</li>
+            <li>
+              Run:{" "}
+              <code className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200">
+                python3 server.py
+              </code>
+            </li>
+            <li>Try running your code again</li>
+          </ol>
+          <button
+            onClick={() => setIsOpen(false)}
+            className="w-full mt-6 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 active:scale-95"
+          >
+            Close
+          </button>
+        </div>
+      </PopupBox>
+    </PopupModal>
+  );
+};
+
+export default LocalRunnerAlert;

--- a/src/components/global/popups/LocalRunnerAlert.tsx
+++ b/src/components/global/popups/LocalRunnerAlert.tsx
@@ -30,7 +30,7 @@ const LocalRunnerAlert: React.FC<LocalRunnerAlertProps> = ({ isOpen, setIsOpen, 
             <li>
               Run:{" "}
               <code className="px-2 py-1 bg-gray-200 dark:bg-gray-700 rounded text-gray-800 dark:text-gray-200">
-                python3 server.py
+                python3 start.py
               </code>
             </li>
             <li>Try running your code again</li>

--- a/src/components/main/page.tsx
+++ b/src/components/main/page.tsx
@@ -13,6 +13,7 @@ import { initializeStorage } from '../../utils/services/storageService';
 import { loadCodeWithCursor } from '../../utils/codeHandlers';
 import { accessRestrictionMessage } from '../../data/constants';
 import ApiLimitAlert from '../global/popups/ApiLimitAlert';
+import LocalRunnerAlert from '../global/popups/LocalRunnerAlert';
 import CodeEditor from './editor/CodeEditor';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { browserAPI } from '../../utils/browser/browserDetect';
@@ -42,7 +43,7 @@ const Main: React.FC<MainProps> = ({ showOptions, setShowOptions, theme }) => {
     } = useCFStore();
 
     // Custom hooks
-    const { runCode, showApiLimitAlert, setShowApiLimitAlert } = useCodeExecution(monacoInstanceRef.current);
+    const { runCode, showApiLimitAlert, setShowApiLimitAlert, showLocalRunnerAlert, setShowLocalRunnerAlert } = useCodeExecution(monacoInstanceRef.current);
     const { handleResetCode, handleLanguageChange, handleFontSizeChange, handleRedirectToLatestSubmission } = useCodeManagement(monacoInstanceRef);
     const { loadTestCases, setupTestCaseListener } = useTestCases();
     const { handleTabEvents } = useTabEvents();
@@ -247,6 +248,11 @@ const Main: React.FC<MainProps> = ({ showOptions, setShowOptions, theme }) => {
                 isOpen={showApiLimitAlert}
                 setIsOpen={setShowApiLimitAlert}
             />
+        	<LocalRunnerAlert
+            	isOpen={showLocalRunnerAlert}
+            	setIsOpen={setShowLocalRunnerAlert}
+            	port={Number(localStorage.getItem('localRunnerPort')) || 5000}
+        	/>
             <TopBar
                 theme={theme as "light" | "dark"}
                 handleClick={() => handleSubmission(monacoInstanceRef.current, setIsSubmitting, language, testCases)}

--- a/src/utils/execution/executeLocal.ts
+++ b/src/utils/execution/executeLocal.ts
@@ -1,0 +1,60 @@
+import { ExecutionParams, ExecutionResult } from './types';
+
+async function checkLocalServer(port: number): Promise<boolean> {
+    try {
+        const res = await fetch(`http://localhost:${port}/health`, {
+            method: 'GET',
+        });
+        return res.ok;
+    } catch {
+        return false;
+    }
+}
+
+export async function executeLocal(
+    params: ExecutionParams,
+    signal?: AbortSignal
+): Promise<ExecutionResult> {
+    const port = Number(localStorage.getItem('localRunnerPort')) || 5000;
+
+    const isAlive = await checkLocalServer(port);
+
+    if (!isAlive) {
+        return {
+            errorMessage: `Local runner is not reachable on port ${port}.
+
+Make sure the local server is running:
+python3 server.py`,
+            outputs: [],
+        };
+    }
+
+    const res = await fetch(`http://localhost:${port}/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params),
+        signal,
+    });
+
+    if (!res.ok) {
+        return {
+            errorMessage: `Local runner returned an error (HTTP ${res.status})`,
+            outputs: [],
+        };
+    }
+
+    const data = await res.json();
+
+    if (data.compile_error) {
+        return {
+            errorMessage: data.compile_error,
+            outputs: [],
+        };
+    }
+
+    return {
+        outputs: data.results.map((r: any) => r.stdout || r.stderr || ''),
+        time: data.results.map((r: any) => r.time || '0'),
+        memory: [],
+    };
+}

--- a/src/utils/execution/types.ts
+++ b/src/utils/execution/types.ts
@@ -1,0 +1,13 @@
+export type ExecutionParams = {
+    code: string;
+    language: string;
+    inputs: string[];
+    timeLimit: number;
+};
+
+export type ExecutionResult = {
+    outputs: string[];
+    time?: string[];
+    memory?: string[];
+    errorMessage?: string;
+};


### PR DESCRIPTION
## Summary

This adds an optional local execution backend to Codeforces-Lite, allowing users to run code on their own machine instead of using Judge0.

The existing Judge0 flow is unchanged and remains the default.

---

## What’s included

- Local execution server (`cf-local-runner`)
  - Supports C, C++, and Python
  - Binary caching for C/C++
  - Automatic cleanup on startup and shutdown
  - Cross-platform (Linux / macOS / Windows*)
- Frontend support for switching execution backend
- Graceful fallback and user-facing alerts when local runner is unavailable
- No changes to Judge0 logic or API behavior

\* C/C++ on Windows requires WSL, MinGW, or MSYS2.

---

## How it works

- Users can switch execution backend via settings
- When local backend is selected, the extension sends requests to a local server
- If the local runner is not reachable, the UI falls back gracefully with an alert
- Judge0 remains the default backend

---

## Safety notes

- The local runner executes code directly on the user’s machine
- Intended for local development only
- Users should only run trusted code

---

## Testing

- Tested local execution for:
  - Python
  - C++
- Verified Judge0 execution remains unaffected
- Verified clean startup and shutdown (Ctrl+C) for local runner

---


The feature is fully optional and does not affect existing users.