### PR TITLE
Feat : Allow users to add custom Vim Keybindings

### DIFF
--- a/src/components/options/ui/EditorSettings.tsx
+++ b/src/components/options/ui/EditorSettings.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, Code, Settings, Palette, Eye } from 'lucide-react';
 import { useCFStore } from '../../../zustand/useCFStore';
-import { CursorSmoothCaretAnimation, CursorStyle, EditorSettingsTypes, KeyBinding, LineNumber } from '../../../types/types';
+import { CursorSmoothCaretAnimation, CursorStyle, EditorSettingsTypes, KeyBinding, LineNumber, IVimKeyBinding } from '../../../types/types';
 import { useEditorSettings } from '../../../utils/hooks/useEditorSettings';
 import CodeEditor from '../../main/editor/CodeEditor';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
@@ -22,6 +22,25 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
     const setEditorSettings = useCFStore(state => state.setEditorSettings);
     const { getEditorSettings, handleToggle, saveEditorSettings } = useEditorSettings(editorSettings, setEditorSettings);
     const { language, fontSize } = useCFStore();
+
+    const [newVimKey, setNewVimKey] = React.useState('');
+    const [newVimCommand, setNewVimCommand] = React.useState('');
+    const [newVimContext, setNewVimContext] = React.useState('insert');
+
+    const addVimBinding = () => {
+        if (!newVimKey || !newVimCommand) return;
+        const newBinding: IVimKeyBinding = { key: newVimKey, command: newVimCommand, context: newVimContext };
+        const updatedBindings = [...(editorSettings.vimKeyBindings || []), newBinding];
+        setEditorSettings({ ...editorSettings, vimKeyBindings: updatedBindings });
+        setNewVimKey('');
+        setNewVimCommand('');
+    };
+
+    const removeVimBinding = (index: number) => {
+        const updatedBindings = [...(editorSettings.vimKeyBindings || [])];
+        updatedBindings.splice(index, 1);
+        setEditorSettings({ ...editorSettings, vimKeyBindings: updatedBindings });
+    };
 
     useEffect(() => {
         if (isOpen) {
@@ -279,6 +298,77 @@ const EditorSettings: React.FC<EditorSettingsProps> = ({ isOpen, onClose }) => {
                                                 Keybinding to use in the editor
                                             </p>
                                         </div>
+
+                                    {editorSettings.keyBinding === 'vim' && (
+                                        <div className="mt-6 p-4 rounded-lg bg-gray-50 dark:bg-[#222222] border border-gray-200 dark:border-gray-800 col-span-1 md:col-span-2">
+                                            <h4 className="text-md font-semibold text-gray-800 dark:text-gray-200 mb-3">Custom Vim Keybindings</h4>
+                                            
+                                            <div className="flex gap-2 mb-4 items-end">
+                                                <div className="flex-1">
+                                                    <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Key</label>
+                                                    <input
+                                                        type="text"
+                                                        placeholder="e.g. jk"
+                                                        value={newVimKey}
+                                                        onChange={(e) => setNewVimKey(e.target.value)}
+                                                        className="w-full bg-white dark:bg-[#2a2a2a] px-3 py-2 text-sm text-gray-700 dark:text-zinc-100 rounded-md border border-gray-300 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                    />
+                                                </div>
+                                                <div className="flex-1">
+                                                    <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Command</label>
+                                                    <input
+                                                        type="text"
+                                                        placeholder="e.g. <Esc>"
+                                                        value={newVimCommand}
+                                                        onChange={(e) => setNewVimCommand(e.target.value)}
+                                                        className="w-full bg-white dark:bg-[#2a2a2a] px-3 py-2 text-sm text-gray-700 dark:text-zinc-100 rounded-md border border-gray-300 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                    />
+                                                </div>
+                                                <div className="w-24">
+                                                    <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Context</label>
+                                                    <select
+                                                        value={newVimContext}
+                                                        onChange={(e) => setNewVimContext(e.target.value)}
+                                                        className="w-full bg-white dark:bg-[#2a2a2a] px-3 py-2 text-sm text-gray-700 dark:text-zinc-100 rounded-md border border-gray-300 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                                    >
+                                                        <option value="insert">Insert</option>
+                                                        <option value="normal">Normal</option>
+                                                        <option value="visual">Visual</option>
+                                                    </select>
+                                                </div>
+                                                <button
+                                                    onClick={addVimBinding}
+                                                    disabled={!newVimKey || !newVimCommand}
+                                                    className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center text-sm"
+                                                >
+                                                    Add
+                                                </button>
+                                            </div>
+
+                                            {editorSettings.vimKeyBindings && editorSettings.vimKeyBindings.length > 0 ? (
+                                                <div className="space-y-2 max-h-40 overflow-y-auto">
+                                                    {editorSettings.vimKeyBindings.map((binding, index) => (
+                                                        <div key={index} className="flex items-center justify-between p-2 bg-white dark:bg-[#2a2a2a] rounded border border-gray-200 dark:border-gray-700">
+                                                            <div className="flex items-center gap-2 text-sm">
+                                                                <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-gray-800 dark:text-gray-200">{binding.key}</span>
+                                                                <span className="text-gray-400">→</span>
+                                                                <span className="font-mono bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-gray-800 dark:text-gray-200">{binding.command}</span>
+                                                                <span className="text-xs text-gray-500 dark:text-gray-400">({binding.context})</span>
+                                                            </div>
+                                                            <button
+                                                                onClick={() => removeVimBinding(index)}
+                                                                className="text-red-500 hover:text-red-700 p-1 rounded hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                                                            >
+                                                                <X size={14} />
+                                                            </button>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            ) : (
+                                                <p className="text-xs text-gray-500 dark:text-gray-400 text-center py-2">No custom keybindings added.</p>
+                                            )}
+                                        </div>
+                                    )}
 
                                         <div className="space-y-2">
                                             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -53,7 +53,8 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettingsTypes = {
   lineNumbers: "on",
   keyBinding: "standard",
   cursorSmoothCaretAnimation: "off",
-  cursorStyle: "line"
+  cursorStyle: "line",
+  vimKeyBindings: []
 };
 
 export const DEFAULT_SHORTCUT_SETTINGS: ShortcutSettings = {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -103,6 +103,12 @@ export type LineNumber = "on" | "off" | "relative";
 export type CursorSmoothCaretAnimation = "on" | "off" | "explicit";
 export type CursorStyle = 'line' | 'block' | 'underline' | 'line-thin' | 'block-outline' | 'underline-thin';
 
+export interface IVimKeyBinding {
+    key: string;
+    command: string;
+    context: string;
+}
+
 export interface EditorSettingsTypes {
     indentSize: number;
     theme: string;
@@ -113,6 +119,7 @@ export interface EditorSettingsTypes {
     keyBinding: KeyBinding;
     cursorSmoothCaretAnimation: CursorSmoothCaretAnimation;
     cursorStyle: CursorStyle;
+    vimKeyBindings: IVimKeyBinding[];
 }
 
 export interface IVimEditor extends monaco.editor.IStandaloneCodeEditor {

--- a/src/utils/hooks/useEditorSettings.ts
+++ b/src/utils/hooks/useEditorSettings.ts
@@ -1,7 +1,7 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { EditorSettingsTypes, IVimEditor } from '../../types/types';
 import { DEFAULT_EDITOR_SETTINGS } from '../../data/constants';
-import { initVimMode } from 'monaco-vim';
+import { initVimMode, VimMode } from 'monaco-vim';
 
 export const useEditorSettings = (editorSettings: EditorSettingsTypes, setEditorSettings: (settings: EditorSettingsTypes) => void) => {
 
@@ -61,6 +61,19 @@ export const useEditorSettings = (editorSettings: EditorSettingsTypes, setEditor
             if(editorSettings.keyBinding == "vim") {
                 if(!vimEditor.vimMode) {
                     vimEditor.vimMode = initVimMode(editor, vimEditor.vimStatusRef.current);
+                }
+                
+                // Apply custom key bindings
+                if (editorSettings.vimKeyBindings && editorSettings.vimKeyBindings.length > 0) {
+                    try {
+                        editorSettings.vimKeyBindings.forEach(({ key, command, context }) => {
+                            if (key && command && context) {
+                                (VimMode as any).Vim.map(key, command, context);
+                            }
+                        });
+                    } catch (error) {
+                        console.error('Failed to apply custom vim bindings:', error);
+                    }
                 }
             } else {
                 if (vimEditor.vimMode) {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -5,121 +5,142 @@ import CopyWebpackPlugin from "copy-webpack-plugin";
 import MonacoWebpackPlugin from "monaco-editor-webpack-plugin";
 import BundleAnalyzerPlugin from "webpack-bundle-analyzer";
 
-const targetBrowser = process.env.TARGET_BROWSER || 'chrome';
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const targetBrowser = process.env.TARGET_BROWSER || "chrome";
 
 const config: webpack.Configuration = {
-    mode: (process.env.NODE_ENV as "development" | "production" | "none") || 'development',
-    entry: {
-        sidepanel: path.resolve(__dirname, 'src/main.tsx'),
+  mode:
+    (process.env.NODE_ENV as "development" | "production" | "none") ||
+    "development",
+  entry: {
+    sidepanel: path.resolve(__dirname, "src/main.tsx"),
+  },
+  output: {
+    path: path.resolve(__dirname, `dist/${targetBrowser}`),
+    filename: "[name].bundle.js",
+    publicPath: "",
+    globalObject: "self",
+    clean: true,
+  },
+  cache: {
+    type: "filesystem",
+    buildDependencies: {
+      config: [__filename],
     },
-    output: {
-        path: path.resolve(__dirname, `dist/${targetBrowser}`),
-        filename: '[name].bundle.js',
-        publicPath: '',
-        globalObject: 'self',
-        clean: true,
-    },
-    cache: {
-        type: 'filesystem',
-        buildDependencies: {
-            config: [__filename],
-        },
-    },
-    module: {
-        rules: [
-            {
-                test: /\.(ts|tsx)$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: 'babel-loader',
-                    options: {
-                        presets: [
-                            '@babel/preset-env',
-                            ['@babel/preset-react', { runtime: 'automatic' }],
-                            '@babel/preset-typescript'
-                        ]
-                    }
-                }
-            },
-            {
-                test: /\.css$/,
-                exclude: /node_modules/,
-                use: [
-                    'style-loader',
-                    'css-loader',
-                    'postcss-loader'
-                ],
-            },
-            {
-                test: /\.css$/,
-                include: /node_modules[\\/]monaco-editor/,
-                use: [
-                    'style-loader',
-                    'css-loader'
-                ],
-            },
-            {
-                test: /\.ttf$/,
-                include: /node_modules[\\/]monaco-editor/,
-                type: 'asset/resource',
-            },
-        ],
-    },
-    plugins: [
-        new HtmlWebpackPlugin({
-            template: path.resolve(__dirname, 'index.html'),
-            filename: 'index.html',
-            chunks: ['sidepanel'],
-        }),
-        new CopyWebpackPlugin({
-            patterns: [
-                {
-                    from: path.resolve(__dirname, `public/manifest.${targetBrowser}.json`),
-                    to: path.resolve(__dirname, `dist/${targetBrowser}/manifest.json`),
-                },
-                {
-                    from: path.resolve(__dirname, 'public/assets/icons'),
-                    to: path.resolve(__dirname, `dist/${targetBrowser}/assets/icons`),
-                },
-                {
-                    from: path.resolve(__dirname, 'public/assets/scripts'),
-                    to: path.resolve(__dirname, `dist/${targetBrowser}/assets/scripts`),
-                    globOptions: {
-                        ignore: ['**/serviceWorker.js']
-                    }
-                },
-                {
-                    from: path.resolve(__dirname, 'public/assets/styles'),
-                    to: path.resolve(__dirname, `dist/${targetBrowser}/assets/styles`),
-                },
-                ...(targetBrowser === 'chrome' ? [
-                    {
-                        from: path.resolve(__dirname, 'public/assets/scripts/serviceWorker.js'),
-                        to: path.resolve(__dirname, `dist/${targetBrowser}/assets/scripts/serviceWorker.js`),
-                    }
-                ] : [])
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: [
+              "@babel/preset-env",
+              ["@babel/preset-react", { runtime: "automatic" }],
+              "@babel/preset-typescript",
             ],
-        }),
-        new MonacoWebpackPlugin({
-            languages: ['cpp', 'java', 'python', 'javascript', 'kotlin', 'go', 'rust', 'ruby'],
-            filename: '[name].worker.js',
-        }),
-        new BundleAnalyzerPlugin.BundleAnalyzerPlugin({
-            analyzerMode: 'disabled', // static to generate report.html
-            openAnalyzer: false,
-        })
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        exclude: /node_modules/,
+        use: ["style-loader", "css-loader", "postcss-loader"],
+      },
+      {
+        test: /\.css$/,
+        include: /node_modules[\\/]monaco-editor/,
+        use: ["style-loader", "css-loader"],
+      },
+      {
+        test: /\.ttf$/,
+        include: /node_modules[\\/]monaco-editor/,
+        type: "asset/resource",
+      },
     ],
-    // optimization: {
-    //     splitChunks: {
-    //         chunks: 'all',
-    //         maxSize: 2000000, // 2MB chunks
-    //     },
-    //     usedExports: true,
-    // },
-    resolve: {
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
-    },
-    devtool: process.env.NODE_ENV === 'development' ? 'source-map' : 'hidden-source-map',
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, "index.html"),
+      filename: "index.html",
+      chunks: ["sidepanel"],
+    }),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: path.resolve(
+            __dirname,
+            `public/manifest.${targetBrowser}.json`,
+          ),
+          to: path.resolve(__dirname, `dist/${targetBrowser}/manifest.json`),
+        },
+        {
+          from: path.resolve(__dirname, "public/assets/icons"),
+          to: path.resolve(__dirname, `dist/${targetBrowser}/assets/icons`),
+        },
+        {
+          from: path.resolve(__dirname, "public/assets/scripts"),
+          to: path.resolve(__dirname, `dist/${targetBrowser}/assets/scripts`),
+          globOptions: {
+            ignore: ["**/serviceWorker.js"],
+          },
+        },
+        {
+          from: path.resolve(__dirname, "public/assets/styles"),
+          to: path.resolve(__dirname, `dist/${targetBrowser}/assets/styles`),
+        },
+        ...(targetBrowser === "chrome"
+          ? [
+              {
+                from: path.resolve(
+                  __dirname,
+                  "public/assets/scripts/serviceWorker.js",
+                ),
+                to: path.resolve(
+                  __dirname,
+                  `dist/${targetBrowser}/assets/scripts/serviceWorker.js`,
+                ),
+              },
+            ]
+          : []),
+      ],
+    }),
+    new MonacoWebpackPlugin({
+      languages: [
+        "cpp",
+        "java",
+        "python",
+        "javascript",
+        "kotlin",
+        "go",
+        "rust",
+        "ruby",
+      ],
+      filename: "[name].worker.js",
+    }),
+    new BundleAnalyzerPlugin.BundleAnalyzerPlugin({
+      analyzerMode: "disabled", // static to generate report.html
+      openAnalyzer: false,
+    }),
+  ],
+  // optimization: {
+  //     splitChunks: {
+  //         chunks: 'all',
+  //         maxSize: 2000000, // 2MB chunks
+  //     },
+  //     usedExports: true,
+  // },
+  resolve: {
+    extensions: [".js", ".jsx", ".ts", ".tsx"],
+  },
+  devtool:
+    process.env.NODE_ENV === "development" ? "source-map" : "hidden-source-map",
 };
 
 export default config;


### PR DESCRIPTION
### Add Support for Custom Vim Keybindings in Editor Settings

Many Vim users prefer alternative key sequences to switch modes or trigger commands. For example, instead of pressing `Esc` to exit **insert mode**, some users prefer pressing `jj` or `jk` for faster typing.

Providing customizable Vim keybindings allows users to tailor the editor behavior to match their existing Vim workflows.

#### Example Configuration

**Exit insert mode using `jj`:**

```json
{
  "key": "jj",
  "command": "<Esc>",
  "mode": "insert"
}
```

With this configuration, pressing `jj` consecutively in **insert mode** will switch to **normal mode**.

#### Note : other keybindings can also set be added.

Demo : 

https://github.com/user-attachments/assets/f163259e-7ff5-4fdf-8e7f-fbac531ec715




